### PR TITLE
Final wave music changes, first wave DL display fix

### DIFF
--- a/Assets/Code/Scripts/Audio/DualAudioEmitter.cs
+++ b/Assets/Code/Scripts/Audio/DualAudioEmitter.cs
@@ -93,6 +93,7 @@ public class DualAudioEmitter : MonoBehaviour
         {
             audioSourceArray[i].Stop();
             audioSourceArray[i].clip = null;
+            audioSourceArray[i].loop = false;
         }
         StopCoroutineSetFullVolume();
 
@@ -137,6 +138,14 @@ public class DualAudioEmitter : MonoBehaviour
     {
         audioSourceArray[1 - toggle].mute = enabled;
         audioSourceArray[toggle].mute = enabled;
+    }
+
+    /// <summary>
+    /// Looping call for the level complete state entry
+    /// </summary>
+    public void Loop()
+    {
+        audioSourceArray[1 - toggle].loop = enabled;
     }
 
     /// <summary>

--- a/Assets/Code/Scripts/Audio/Jukebox.cs
+++ b/Assets/Code/Scripts/Audio/Jukebox.cs
@@ -41,6 +41,7 @@ public class Jukebox : MonoBehaviour, IResettable
 
         GameStateController.playing.notifyListenersEnter += HandlePlayingEnter;
         GameStateController.playing.notifyListenersExit += HandlePlayingExit;
+        GameStateController.levelComplete.notifyListenersEnter += HandleLevelComplete;
 
         radioWasPlayingLastFrame = false;
     }
@@ -63,8 +64,7 @@ public class Jukebox : MonoBehaviour, IResettable
         }
 
 
-
-        if (radioClipPlayer.IsPlaying != radioWasPlayingLastFrame) 
+        if (radioClipPlayer.IsPlaying != radioWasPlayingLastFrame)
         {
             radioWasPlayingLastFrame = radioClipPlayer.IsPlaying;
             TriggerRadioStatusUpdate();
@@ -96,6 +96,10 @@ public class Jukebox : MonoBehaviour, IResettable
     {
         if (sequence.CurrentWaveIsFinal)
         {
+            //Play the LevelComplete wave's final audio loop
+            AudioClip clipToPlay = sequence.GetCurrentTrackVariation();
+            musicPlayer.QueueNextSong(clipToPlay, nextAudioLoopTime);
+
             sequence.SpawnNewWave();
         }
         else
@@ -173,12 +177,25 @@ public class Jukebox : MonoBehaviour, IResettable
         canPlay = false;
     }
 
-    public void HandleInBoundsEnter() 
+    /// <summary>
+    /// Handles logic for completing the game
+    /// </summary>
+    private void HandleLevelComplete()
+    {
+        musicPlayer.Play();
+        musicPlayer.Loop();
+        radioClipPlayer.Pause();
+        nextAudioLoopDifference = nextAudioLoopTime - AudioSettings.dspTime;
+
+        canPlay = false;
+    }
+
+    public void HandleInBoundsEnter()
     {
         TriggerRadioStatusUpdate();
     }
 
-    private void TriggerRadioStatusUpdate() 
+    private void TriggerRadioStatusUpdate()
     {
         onRadioStatusUpdate?.Invoke(radioClipPlayer.IsPlaying);
     }

--- a/Assets/Code/Scripts/SceneManageMent/Waves/LevelCompleteWave.cs
+++ b/Assets/Code/Scripts/SceneManageMent/Waves/LevelCompleteWave.cs
@@ -10,7 +10,7 @@ using Waves;
 [CreateAssetMenu(menuName = "Wave/LevelComplete Wave", fileName = "New LevelComplete Wave")]
 public class LevelCompleteWave : Wave
 {
-    [SerializeField] public AudioClip finalMusicLoop;
+    [SerializeField] private AudioClip finalMusicLoop;
 
     public override WaveType GetWaveType()
     {

--- a/Assets/Code/Scripts/SceneManageMent/Waves/LevelCompleteWave.cs
+++ b/Assets/Code/Scripts/SceneManageMent/Waves/LevelCompleteWave.cs
@@ -10,6 +10,8 @@ using Waves;
 [CreateAssetMenu(menuName = "Wave/LevelComplete Wave", fileName = "New LevelComplete Wave")]
 public class LevelCompleteWave : Wave
 {
+    [SerializeField] public AudioClip finalMusicLoop;
+
     public override WaveType GetWaveType()
     {
         return WaveType.LevelComplete;
@@ -19,5 +21,10 @@ public class LevelCompleteWave : Wave
     {
         GameStateController.HandleTrigger(StateTrigger.LevelComplete);
         return null;
+    }
+
+    public AudioClip GetTrackVariation()
+    {
+        return finalMusicLoop;
     }
 }

--- a/Assets/Code/Scripts/SceneManageMent/Waves/Wave.cs
+++ b/Assets/Code/Scripts/SceneManageMent/Waves/Wave.cs
@@ -6,6 +6,12 @@ using UnityEngine.SceneManagement;
 
 namespace Waves
 {
+    /// <summary>
+    /// WaveType is an enum of type HostileWave, LevelComplete, or AudioWave.
+    /// HostileWave spawns enemies and plays music,
+    /// LevelComplete indicates the wave action to trigger game end,
+    /// AudioWave spawns enemies, plays music, AND plays a radio clip
+    /// </summary>
     public enum WaveType
     {
         HostileWave, LevelComplete, AudioWave
@@ -36,6 +42,7 @@ namespace Waves
         [SerializeField]
         public int DLThreshold;
 
+        //Returns the type of wave
         public abstract WaveType GetWaveType();
 
         //Determines if current DL is above this wave's threshold

--- a/Assets/Code/Scripts/SceneManageMent/Waves/WaveSequence.cs
+++ b/Assets/Code/Scripts/SceneManageMent/Waves/WaveSequence.cs
@@ -39,7 +39,7 @@ namespace EditorObject
 
         public bool CurrentWaveIsFinal
         {
-            get => currentWave == sequence.Count - 1;
+            get => sequence[currentWave].GetWaveType() == WaveType.LevelComplete;
         }
 
         public AudioClip GetCurrentRadioClip
@@ -74,7 +74,8 @@ namespace EditorObject
             }
             else
             {
-                return null;
+                LevelCompleteWave wave = (LevelCompleteWave)sequence[currentWave];
+                return wave.GetTrackVariation();
             }
         }
 
@@ -115,6 +116,10 @@ namespace EditorObject
             spawner = squadSpawner;
             currentWave = 0;
             previousWave = -1;
+
+            //Set the initial DlThreshold for the first wave (used in gameplay UI)
+            int nextThreshold = sequence[0].DLThreshold;
+            DangerLevel.Instance.SetDlThreshold(0, nextThreshold);
         }
         /// <summary>
         /// Gets the universal time that the next wave will spawn at,
@@ -145,6 +150,10 @@ namespace EditorObject
             currentWave = 0;
             previousWave = -1;
             hasAlreadyPlayedRadioClip = false;
+
+            //Set the initial DlThreshold for the first wave (used in gameplay UI)
+            int nextThreshold = sequence[0].DLThreshold;
+            DangerLevel.Instance.SetDlThreshold(0, nextThreshold);
         }
     }
 }

--- a/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave1.asset
+++ b/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave1.asset
@@ -12,9 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 327e0d072a3926a46be00b473da0fa7a, type: 3}
   m_Name: WastelandSoulWave1
   m_EditorClassIdentifier: 
-  DLThreshold: 80
+  DLThreshold: 60
   waveEnemies:
   - enemyType: 0
     spawnLocation: 2
+  - enemyType: 0
+    spawnLocation: 4
   TrackVariation: {fileID: 8300000, guid: 68cbf794b7c515b4da4e708de5937a50, type: 3}
   RadioClip: {fileID: 8300000, guid: 128ffe0bb2c3c0742a5e8d5de9343b13, type: 3}

--- a/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave2.asset
+++ b/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave2.asset
@@ -14,7 +14,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DLThreshold: 160
   waveEnemies:
-  - enemyType: 2
+  - enemyType: 0
     spawnLocation: 3
+  - enemyType: 0
+    spawnLocation: 1
   TrackVariation: {fileID: 8300000, guid: bce47a2d326b7764cb40d276cc8d3ac9, type: 3}
   RadioClip: {fileID: 8300000, guid: 590ca4ce7adef564c95f6be55565e799, type: 3}

--- a/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave3.asset
+++ b/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave3.asset
@@ -16,5 +16,7 @@ MonoBehaviour:
   waveEnemies:
   - enemyType: 0
     spawnLocation: 0
+  - enemyType: 0
+    spawnLocation: 1
   TrackVariation: {fileID: 8300000, guid: 57357c07e0d448b458b32054d3ea60b0, type: 3}
   RadioClip: {fileID: 8300000, guid: 0236bd7df2dc6c8459350a245aebca69, type: 3}

--- a/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave5.asset
+++ b/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave5.asset
@@ -14,7 +14,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DLThreshold: 360
   waveEnemies:
-  - enemyType: 2
+  - enemyType: 0
     spawnLocation: 2
+  - enemyType: 0
+    spawnLocation: 0
   TrackVariation: {fileID: 8300000, guid: bb9e372677c76174d92865e61cd0d2ea, type: 3}
   RadioClip: {fileID: 8300000, guid: f44ed353352d08146a1488bbdf378546, type: 3}

--- a/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave7Complete.asset
+++ b/Assets/EditorObject/WaveSequences/DrivingSynth/WastelandSoulWave7Complete.asset
@@ -13,3 +13,4 @@ MonoBehaviour:
   m_Name: WastelandSoulWave7Complete
   m_EditorClassIdentifier: 
   DLThreshold: 500
+  finalMusicLoop: {fileID: 8300000, guid: b3a667885c9de5343b6623f97485c95d, type: 3}


### PR DESCRIPTION
Refactored a bit of wave functionality by adding an audio track to the final wave that loops on LevelComplete. This allows us to have credits music per-level.

ALSO: the danger level threshold was not displaying properly on the first wave, that's been fixed here.